### PR TITLE
Add support for streaming structured events in nightly test

### DIFF
--- a/gnmi_cli_py/py_gnmicli.py
+++ b/gnmi_cli_py/py_gnmicli.py
@@ -37,6 +37,7 @@ import os
 import re
 import ssl
 import sys
+import string
 import six
 import datetime
 try:
@@ -410,9 +411,9 @@ def gen_request(paths, opt, prefix):
 
 
 def check_event_response(response, filter_event_regex):
-    resp = str(response)
-    match = re.match(filter_event_regex, resp)
-    return match is not None
+    resp = str(response).translate(None, string.whitespace)
+    match = re.findall(filter_event_regex, resp)
+    return match
 
 
 def subscribe_start(stub, options, req_iterator):
@@ -439,9 +440,10 @@ def subscribe_start(stub, options, req_iterator):
               print('gNMI Error '+str(response.error.code)+\
                 ' received\n'+str(response.error.message) + str(response.error))
           elif response.HasField('update'):
-              if filter_event_regex is not None:
-                  if check_event_response(response, filter_event_regex):
-                      print(response)
+              if filter_event_regex is not None and filter_event_regex is not "":
+                  match = check_event_response(response, filter_event_regex)
+                  if len(match) is not 0:
+                      print("{} was found in {}".format(match,response))
                       update_count = update_count + 1
               else:
                   print(response)

--- a/gnmi_cli_py/py_gnmicli.py
+++ b/gnmi_cli_py/py_gnmicli.py
@@ -163,7 +163,7 @@ def _create_parser():
                       help='Creates specific number of TCP connections with gNMI server side. '
                       'Default number of TCP connections is 1 and use -1 to create '
                       'infinite TCP connections.')
-  parser.add_argument('--filter_event_regex', default='', help='Regex to filter event when querying events path (default: none)')
+  parser.add_argument('--filter_event_regex', help='Regex to filter event when querying events path')
   parser.add_argument('--prefix', default='', help='gRPC path prefix (default: none)')
   return parser
 
@@ -411,7 +411,7 @@ def gen_request(paths, opt, prefix):
 
 
 def check_event_response(response, filter_event_regex):
-    resp = str(response).translate(None, string.whitespace)
+    resp = str(response)
     match = re.findall(filter_event_regex, resp)
     return match
 
@@ -440,11 +440,14 @@ def subscribe_start(stub, options, req_iterator):
               print('gNMI Error '+str(response.error.code)+\
                 ' received\n'+str(response.error.message) + str(response.error))
           elif response.HasField('update'):
-              if filter_event_regex is not None and filter_event_regex is not "":
-                  match = check_event_response(response, filter_event_regex)
-                  if len(match) is not 0:
-                      print("{} was found in {}".format(match,response))
-                      update_count = update_count + 1
+              if filter_event_regex is not None:
+                  if filter_event_regex is not "":
+                      match = check_event_response(response, filter_event_regex)
+                      if len(match) is not 0:
+                          print(response)
+                          update_count = update_count + 1
+                  else:
+                      raise Exception("Filter event regex should not be empty")
               else:
                   print(response)
                   update_count = update_count+1

--- a/gnmi_cli_py/py_gnmicli.py
+++ b/gnmi_cli_py/py_gnmicli.py
@@ -60,8 +60,6 @@ _RE_PATH_COMPONENT = re.compile(r'''
 INVALID_GNMI_CLIENT_CONNECTION_NUMBER = 1
 GNMI_SERVER_UNAVAILABLE = 2
 
-EVENT_REGEX = 'json_ietf_val: \"(.*)\"'
-
 class Error(Exception):
   """Module-level Exception class."""
 
@@ -413,16 +411,9 @@ def gen_request(paths, opt, prefix):
 
 
 def handle_event_response(response, event_op_file):
-    regex_matches = re.search(EVENT_REGEX, str(response))
-    if regex_matches:
-        event_str = regex_matches.group(1)
-        event_str = event_str.replace('\\', '')
-        event_json = json.loads(event_str)
-        with open(event_op_file, "w") as f:
-            f.write("[\n")
-            json.dump(event_json, f, indent=4)
-            f.write("\n]")
-            f.close()
+    with open(event_op_file, "w") as f:
+        f.write(str(response))
+        f.close()
 
 
 def subscribe_start(stub, options, req_iterator):


### PR DESCRIPTION
**What is the motivation of this PR?**

This PR adds support for testing structured events as part of nightly test, by adding params:  filter_event and event_op_file
When subscribing to EVENTS/all we will check for filter_event as part of response and then we will add response that contains filter to op_file. Test will then fetch this output file then do parsing logic for yang validation.

**How did you do it?**

I added options filter_event and event_op_file for supporting nightly tests for event

**How did you test/verify it?**

I verify this on the ptf docker container binding to the lab device str-s6000-on-6. The command line I used is as following:
python /gnxi/gnmi_cli_py/py_gnmicli.py -g -t *.*.*.* -p 50051 -m subscribe -x all -xt EVENTS -o "ndastreamingservertest" --filter_event_regex sonic-events-bgp:bgp-state