### PR TITLE
Update protobuf version to be compatible with Python 3.9

### DIFF
--- a/gnmi_cli_py/requirements.txt
+++ b/gnmi_cli_py/requirements.txt
@@ -2,5 +2,5 @@ enum34==1.1.6
 futures==3.2.0
 grpcio==1.41.1
 grpcio-tools==1.41.1
-protobuf==3.15.1 --no-binary=protobuf
+protobuf==3.15.0 --no-binary=protobuf
 six==1.12.0

--- a/gnmi_cli_py/requirements.txt
+++ b/gnmi_cli_py/requirements.txt
@@ -2,5 +2,5 @@ enum34==1.1.6
 futures==3.2.0
 grpcio==1.41.1
 grpcio-tools==1.41.1
-protobuf==3.6.1 --no-binary=protobuf
+protobuf==3.15.1 --no-binary=protobuf
 six==1.12.0


### PR DESCRIPTION
Requirements for `gnmi_cli_py` fails to install in the `docker-ptf` Python 3 only image due to compatibility issues. Protobuf 3.6.1 is not compatible with Python 3.9. This PR updates protobuf to 3.15.0 as it supports Python 3.9.

3.15.0 supports all the Python versions supported by 3.6.1 and includes 3.9.

**Error message seen while install:**

```
  error: subprocess-exited-with-error
                                                      
  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [6 lines of output]                                                                                                       
      Traceback (most recent call last):
        File "<string>", line 2, in <module>                                                                                                                                                                                                                            File "<pip-setuptools-caller>", line 34, in <module>
        File "/tmp/pip-install-235ralu1/protobuf_e9ca493de0a64cf5b03fa238ec34f1cb/setup.py", line 18, in <module>
          from distutils.command.build_py import build_py_2to3 as _build_py
      ImportError: cannot import name 'build_py_2to3' from 'distutils.command.build_py' (/root/env-python3/lib/python3.9/site-packages/setuptools/_distutils/command/build_py.py)                                                                                     [end of output]
```